### PR TITLE
rubyバージョンの更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby "~> 3.2"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.2", ">= 7.2.2.1"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,5 +312,8 @@ DEPENDENCIES
   tzinfo-data
   web-console
 
+RUBY VERSION
+   ruby 3.2.2p53
+
 BUNDLED WITH
    2.4.10


### PR DESCRIPTION
使用するPaaSをherokuに変更し、デプロイしたところrubyバージョンの互換性に対するエラーが出たため修正してデプロイテストを実行する。
rubyバージョンは指定していなかったため、gemファイルに追記後、bundle install。
gem.lockも更新されたのでコミットした。