### PR TITLE
カテゴリーモデルの作成とモデルの設定追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -61,12 +61,52 @@ body {
 }
 
 .form{
-    margin-top: 90px;
+    margin-top: 50px;
 }
 
 .form p{
     text-align: end;
     font-size: 13px;
+}
+
+.category_select{
+    background-color: #ffffff;
+}
+
+.category_form{
+    display: flex;
+    
+}
+
+.category_label{
+    text-align: end;
+    width: 28%;
+    margin-right: 9%;
+}
+
+.category_name{
+    text-align: center;
+    width: 57%;
+    padding: .375rem .75rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    border: 1px solid #ced4da;
+    border-radius: .25rem;
+    background-color: #e9ecef;
+    margin-right: 7%;
+    
+}
+
+.category_name_input{
+    text-align: center;
+    width: 57%;
+    padding: .375rem .75rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    border: 1px solid #ced4da;
+    border-radius: .25rem;
+    background-color: #ffffff;
+    margin-right: 13%; 
 }
 
 .purchase_interval{

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,7 @@
 class Article < ApplicationRecord
     belongs_to :user
+    has_many :article_categories, dependent: :destroy
+    has_many :categories, through: :article_categories
     validates :keyword, presence: true, length: {maximum: 18}
     validates :body, length: {maximum: 120}
 end

--- a/app/models/article_category.rb
+++ b/app/models/article_category.rb
@@ -1,0 +1,4 @@
+class ArticleCategory < ApplicationRecord
+    belongs_to :article
+    belongs_to :category
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,6 @@
+class Category < ApplicationRecord
+    has_many :article_categories
+    has_many :stock_categories
+    has_many :articles, through: :article_categories
+    has_many :stocks, through: :stock_categories
+end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,5 +1,8 @@
 class Stock < ApplicationRecord
     belongs_to :user
+    has_many :stock_categories, dependent: :destroy
+    has_many :categories, through: :stock_categories
+    accepts_nested_attributes_for :stock_categories
     validates :name, presence: true, length: {maximum: 25}
     validates :purchase_interval, allow_blank: true, numericality: {only_integer: true}
     validates :memo, length: {maximum: 120}

--- a/app/models/stock_category.rb
+++ b/app/models/stock_category.rb
@@ -1,0 +1,4 @@
+class StockCategory < ApplicationRecord
+    belongs_to :stock
+    belongs_to :category
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   
-  has_many :stocks
-  has_many :articles
+  has_many :stocks, dependent: :destroy
+  has_many :articles, dependent: :destroy
   validates :password, length: {minimum: 3}, if: -> {new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> {new_record? || changes[:crypted_password] }
   validates :password_confirmation,presence: true, if: -> {new_record? || changes[:crypted_password] }

--- a/app/views/stocks/edit.html.erb
+++ b/app/views/stocks/edit.html.erb
@@ -8,8 +8,15 @@
           <%= f.label :ストック名, class: "label text-center" %>
           <%= f.text_field :name, class: "form-control mr-5 text-center" %>
         </div>  
+
+        <%= f.fields_for :stock_categories do |stock_category| %>
+          <div class="category_form">
+            <%= stock_category.label :カテゴリー, class: "category_label" %>
+            <%= stock_category.collection_select :category_id, Category.all, :id, :name,{}, { class: "category_name_input" } %>
+          </div> 
+        <% end %>
         
-        <div class="d-flex mb-3 mr-5">
+        <div class="d-flex my-3 mr-5">
           <%= f.label :購入頻度, class: "label text-center" %>
           <%= f.text_field :purchase_interval, class: "form-control purchase_interval text-right" %>
           <span class="mr-5 mt-1">日毎に購入</span>

--- a/app/views/stocks/new.html.erb
+++ b/app/views/stocks/new.html.erb
@@ -17,8 +17,15 @@
           <%= f.label :ストック名, class: "label text-center" %>
           <%= f.text_field :name, class: "form-control mr-5 text-center" %>
         </div>  
+
+        <%= f.fields_for :stock_categories do |stock_category| %>
+          <div class="category_form">
+            <%= stock_category.label :カテゴリー, class: "category_label" %>
+            <%= stock_category.collection_select :category_id, Category.all, :id, :name,{}, { class: "category_name_input" } %>
+          </div> 
+        <% end %>
         
-        <div class="d-flex mb-3 mr-5">
+        <div class="d-flex my-3 mr-5">
           <%= f.label :購入頻度, class: "label text-center" %>
           <%= f.text_field :purchase_interval, class: "form-control purchase_interval text-right" %>
           <span class="mr-5 mt-1">日毎に購入</span>

--- a/app/views/stocks/show.html.erb
+++ b/app/views/stocks/show.html.erb
@@ -7,7 +7,14 @@
         <div class="d-flex mb-3 mr-5">
           <%= f.label :ストック名, class: "label text-center" %>
           <%= f.text_field :name, readonly: true, class: "form-control mr-5 text-center" %>
-        </div>  
+        </div> 
+
+        <div class="category_form mb-3 mr-5">
+          <div class="category_label">カテゴリー</div>
+          <div class="category_name">
+            <%= @category %>
+          </div>
+        </div> 
         
         <div class="d-flex mb-3 mr-5">
           <%= f.label :購入頻度, class: "label text-center" %>

--- a/db/migrate/20250327082652_create_categories.rb
+++ b/db/migrate/20250327082652_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250327083029_create_article_categories.rb
+++ b/db/migrate/20250327083029_create_article_categories.rb
@@ -1,0 +1,11 @@
+class CreateArticleCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :article_categories do |t|
+      t.references :article, foreign_key: true
+      t.references :category, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :article_categories, [:article_id, :category_id]
+  end
+end

--- a/db/migrate/20250327090031_create_stock_categories.rb
+++ b/db/migrate/20250327090031_create_stock_categories.rb
@@ -1,0 +1,11 @@
+class CreateStockCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :stock_categories do |t|
+      t.references :stock, foreign_key: true
+      t.references :category, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :stock_categories, [:stock_id, :category_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_25_055916) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_27_090031) do
+  create_table "article_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "article_id"
+    t.bigint "category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id", "category_id"], name: "index_article_categories_on_article_id_and_category_id"
+    t.index ["article_id"], name: "index_article_categories_on_article_id"
+    t.index ["category_id"], name: "index_article_categories_on_category_id"
+  end
+
   create_table "articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "keyword", null: false
     t.string "body", null: false
@@ -18,6 +28,22 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_25_055916) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "stock_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "stock_id"
+    t.bigint "category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_stock_categories_on_category_id"
+    t.index ["stock_id", "category_id"], name: "index_stock_categories_on_stock_id_and_category_id"
+    t.index ["stock_id"], name: "index_stock_categories_on_stock_id"
   end
 
   create_table "stocks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -43,6 +69,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_25_055916) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "article_categories", "articles"
+  add_foreign_key "article_categories", "categories"
   add_foreign_key "articles", "users"
+  add_foreign_key "stock_categories", "categories"
+  add_foreign_key "stock_categories", "stocks"
   add_foreign_key "stocks", "users"
 end


### PR DESCRIPTION
##概要

カテゴリーモデルを作成した。
Stockモデル、Articleモデルに対して中間テーブルを設け複数のカテゴリーを関連付けられるようにした。
⬆️実装中に、関連付けるカテゴリーは１つでいいのではと思い、複数登録できない仕様にしているが、
　運用してみて必要そうであれば複数登録できるように変更する。

また、アソシエーションを設けたモデルに対しては親が削除されると子要素も削除されるようにした。