### PR TITLE
画像用外部ストレージの設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,12 @@ gem 'carrierwave', '~> 3.0'
 
 gem 'mini_magick'
 
+gem 'dotenv-rails'
+
+gem 'aws-sdk-s3'
+
+gem 'fog-aws'
+
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,24 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    aws-eventstream (1.3.2)
+    aws-partitions (1.1102.0)
+    aws-sdk-core (3.223.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.100.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.185.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.11.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -102,8 +120,14 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
+    excon (1.2.5)
+      logger
     faraday (2.12.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -112,6 +136,23 @@ GEM
       net-http (>= 0.5.0)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-x86_64-linux-gnu)
+    fog-aws (3.31.0)
+      base64 (~> 0.2.0)
+      fog-core (~> 2.6)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.6.0)
+      builder
+      excon (~> 1.0)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.5)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -129,6 +170,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.10.1)
     jwt (2.10.1)
       base64
@@ -155,6 +197,10 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0507)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -339,10 +385,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap
   brakeman
   carrierwave (~> 3.0)
   debug
+  dotenv-rails
+  fog-aws
   importmap-rails
   letter_opener_web (~> 3.0)
   mini_magick

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -5,8 +5,25 @@ class PhotoUploader < CarrierWave::Uploader::Base
   # include CarrierWave::Vips
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+
+  CarrierWave.configure do |config|
+    if Rails.env.production?
+      config.storage :fog
+      config.fog_provider = 'fog/aws'
+      config.fog_directory  = ENV['AWS_BUCKET']
+      config.fog_public = false
+      config.fog_credentials = {
+        provider: 'AWS',
+        aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+        aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+        region: ENV['AWS_REGION'],
+        path_style: true
+      }
+    else
+      config.storage :file
+    end
+  end
+  
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,12 +7,12 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+#amazon:
+ # service: S3
+ # access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+ # secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+ # region: <%= ENV['AWS_REGION'] %>
+ # bucket: <%= ENV['AWS_BUCKET'] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
## 概要

画像の保存先として外部ストレージ（AWS S3）を登録した。
ブランチ名はActiveStorageとしてしまっているが、実際はCarrierwaveを使用しているため、uploader経由で保存している。