### PR TITLE
LINEプッシュ通知機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'omniauth-auth0'
 gem 'omniauth-line'
 gem 'omniauth-rails_csrf_protection'
 
+gem 'line-bot-api', require: 'line/bot'
+
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,9 @@ GEM
       letter_opener (~> 1.9)
       railties (>= 6.1)
       rexml
+    line-bot-api (2.0.0)
+      base64 (~> 0.2)
+      multipart-post (~> 2.4)
     lint_roller (1.1.0)
     logger (1.6.6)
     loofah (2.24.0)
@@ -210,6 +213,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
+    multipart-post (2.4.1)
     mysql2 (0.5.6)
     net-http (0.6.0)
       uri
@@ -414,6 +418,7 @@ DEPENDENCIES
   fog-aws
   importmap-rails
   letter_opener_web (~> 3.0)
+  line-bot-api
   mini_magick
   mysql2 (~> 0.5)
   omniauth-auth0

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -7,4 +7,20 @@ class Stock < ApplicationRecord
     validates :purchase_interval, allow_blank: true, numericality: {only_integer: true}
     validates :memo, length: {maximum: 120}
     validates :stock_quantity, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+    def line_push
+        client ||= Line::Bot::V2::MessagingApi::ApiClient.new(
+            channel_access_token: ENV.fetch("LINE_CHANNEL_TOKEN_MESSAGE")
+        )
+
+        request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(
+            to: self.user.email,
+            messages: [
+                Line::Bot::V2::MessagingApi::TextMessage.new(text: "#{self.user.name}さま　\n残り１つとなった在庫をお知らせします!\n\n#{self.name}")
+            ]
+        )
+        
+        response = client.push_message(push_message_request: request)
+        puts response
+    end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,6 @@ require "action_mailbox/engine"
 require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
-
 require 'omniauth'
 
 # require "rails/test_unit/railtie"

--- a/lib/tasks/auto_management.rake
+++ b/lib/tasks/auto_management.rake
@@ -1,4 +1,34 @@
+namespace :auto_management do
+    desc "在庫の自動管理(引き落とし)"
+    task auto_decrease: :environment do
+        Stock.find_each do |stock|
+            passed_days = (Date.current - stock.quantity_update_at.to_date).to_i
 
+            if stock.purchase_interval != nil
+                if passed_days >= stock.purchase_interval
+                    stock.stock_quantity -= 1
+                    if stock.stock_quantity == 1
+                        if stock.user.email.include?("@")
+                            StockMailer.send_stock_letter(stock.id).deliver_now
+                        else
+                            stock.line_push
+                        end
+                    end
+                    stock.quantity_update_at = Time.current
+                    stock.save
+                end
+            end
+        end
+    end
+
+    task send_stock_letter: :environment do
+        StockMailer.test.deliver_now
+    end
+end
+
+
+
+=begin Mailerテスト
 namespace :auto_management do
     desc "在庫の自動管理(引き落とし)"
     task auto_decrease: :environment do
@@ -21,5 +51,29 @@ namespace :auto_management do
     task send_stock_letter: :environment do
         StockMailer.test.deliver_now
     end
-
 end
+
+
+LINE通知テスト
+namespace :push_task do
+    desc "LINEBOT：タスクの通知" 
+    task :push_line_message_task => :environment do
+        client ||= Line::Bot::V2::MessagingApi::ApiClient.new(
+            channel_access_token: ENV.fetch("LINE_CHANNEL_TOKEN_MESSAGE")
+        )
+
+        stock = Stock.find(48)
+        user = User.find_by(email: stock.user.email)
+        request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(
+            to: stock.user.email,
+            messages: [
+                Line::Bot::V2::MessagingApi::TextMessage.new(text: "#{stock.user.name}さま　\n残り１つとなった在庫をお知らせします!\n\n#{user.stocks.first.name}")
+            ]
+        )
+        
+        response = client.push_message(push_message_request: request)
+        puts response
+          
+    end
+=end
+


### PR DESCRIPTION
## 概要

追加したgem：　line-bot-api
在庫数が１となったものがあればLINEへプッシュ通知できる機能を実装した。
メールアドレスで登録しているユーザーに対してはメールで送信する分岐を設けている。
